### PR TITLE
[Bug-fix] Image transport memory leak

### DIFF
--- a/include/realsense_gazebo_plugin/gazebo_ros_realsense.h
+++ b/include/realsense_gazebo_plugin/gazebo_ros_realsense.h
@@ -63,7 +63,7 @@ protected:
   rclcpp::Node::SharedPtr node_;
 
 private:
-  image_transport::ImageTransport * itnode_;
+  std::unique_ptr<image_transport::ImageTransport> itnode_;
 
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_pub_;
 

--- a/src/gazebo_ros_realsense.cpp
+++ b/src/gazebo_ros_realsense.cpp
@@ -49,7 +49,7 @@ void GazeboRosRealsense::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   this->camera_info_manager_.reset(
     new camera_info_manager::CameraInfoManager(this->node_.get(), this->GetHandle()));
 
-  this->itnode_ = new image_transport::ImageTransport(this->node_);
+  this->itnode_.reset(new image_transport::ImageTransport(this->node_));
 
   this->color_pub_ = this->itnode_->advertiseCamera(
     cameraParamsMap_[COLOR_CAMERA_NAME].topic_name, 2);


### PR DESCRIPTION
Mildly disappointed in myself for not noticing this when I first looked over the realsense_gazebo_plugin ros2 code... There is a memory leak where a pointer to an image transport object is allocated on the heap and never freed. This PR fixes this by using a unique_ptr so ensure the image_transport object gets freed alongside the realsense_gazebo_plugin.