### PR TITLE
Use gazebo_ros Node API so the node is properly configured

### DIFF
--- a/include/realsense_gazebo_plugin/gazebo_ros_realsense.h
+++ b/include/realsense_gazebo_plugin/gazebo_ros_realsense.h
@@ -4,6 +4,7 @@
 #include "realsense_gazebo_plugin/RealSensePlugin.h"
 
 #include <rclcpp/rclcpp.hpp>
+#include <gazebo_ros/node.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -60,7 +61,7 @@ protected:
   ///  A node will be instantiated if it does not exist.
 
 protected:
-  rclcpp::Node::SharedPtr node_;
+  gazebo_ros::Node::SharedPtr node_;
 
 private:
   std::unique_ptr<image_transport::ImageTransport> itnode_;

--- a/src/gazebo_ros_realsense.cpp
+++ b/src/gazebo_ros_realsense.cpp
@@ -27,8 +27,7 @@ GazeboRosRealsense::~GazeboRosRealsense()
 
 void GazeboRosRealsense::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
 {
-
-  this->node_ = rclcpp::Node::make_shared("GazeboRealsenseNode");
+  this->node_ = gazebo_ros::Node::CreateWithArgs("GazeboRealsenseNode");
 
   // Make sure the ROS node for Gazebo has already been initialized
   if (!rclcpp::ok()) {


### PR DESCRIPTION
Previously, rclcpp::Node was used to create a node for the realsense gazebo plugin to use. This is not sustainable because it is not properly configured, spun, and connected to the ros graph. So you get error messages like this:
```
ros param list
Exception while calling service of node '/GazeboRealsenseNode': None
Traceback (most recent call last):
  File "/opt/ros/galactic/bin/ros2", line 11, in <module>
    load_entry_point('ros2cli==0.13.1', 'console_scripts', 'ros2')()
  File "/opt/ros/galactic/lib/python3.8/site-packages/ros2cli/cli.py", line 67, in main
    rc = extension.main(parser=parser, args=args)
  File "/opt/ros/galactic/lib/python3.8/site-packages/ros2param/command/param.py", line 39, in main
    return extension.main(args=args)
  File "/opt/ros/galactic/lib/python3.8/site-packages/ros2param/verb/list.py", line 116, in main
    sorted_names = sorted(response.result.names)
AttributeError: 'NoneType' object has no attribute 'result'
```
This PR sets up the node using the gazebo_ros::Node API to fix that problem.